### PR TITLE
Update runtime to GNOME 46

### DIFF
--- a/org.gnumeric.Gnumeric.json
+++ b/org.gnumeric.Gnumeric.json
@@ -1,7 +1,7 @@
 {
     "id": "org.gnumeric.Gnumeric",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "gnumeric",
     "rename-icon": "org.gnumeric.gnumeric",
@@ -128,9 +128,6 @@
             "cleanup": [
                 "/include"
             ],
-            "post-install": [
-                "appstream-util modify $FLATPAK_DEST/share/metainfo/org.gnumeric.gnumeric.appdata.xml id $FLATPAK_ID"
-            ],
             "sources": [
                 {
                     "type": "archive",
@@ -141,6 +138,10 @@
                         "name": "gnumeric",
                         "stable-only": true
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/gnumerica-appstream.patch"
                 }
             ]
         }

--- a/patches/gnumerica-appstream.patch
+++ b/patches/gnumerica-appstream.patch
@@ -1,0 +1,12 @@
+diff --git a/org.gnumeric.gnumeric.appdata.xml.in b/org.gnumeric.gnumeric.appdata.xml.in
+index 85b1b02..7e22ec4 100644
+--- a/org.gnumeric.gnumeric.appdata.xml.in
++++ b/org.gnumeric.gnumeric.appdata.xml.in
+@@ -54,7 +54,6 @@
+     <kudo>HiDpiIcon</kudo>
+     <kudo>ModernToolkit</kudo>
+   </kudos>
+-  <project_group>GNOME</project_group>
+   <_developer_name>The Gnumeric Team</_developer_name>
+   <url type="homepage">http://www.gnumeric.org/</url>
+   <url type="bugtracker">https://gitlab.gnome.org/GNOME/gnumeric/issues</url>


### PR DESCRIPTION
- Also use built-in rename for appid
- Fix #14
- Fix appstream file.